### PR TITLE
Add Tally intergration

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "bignumber.js": "^9.0.0",
     "bitcoin-address-validation": "^1.0.2",
     "bnc-notify": "^1.2.2",
-    "bnc-onboard": "^1.12.0",
+    "bnc-onboard": "^1.37.0",
     "break_infinity.js": "^1.1.0",
     "comlink": "^4.2.0",
     "core-js": "^3.6.4",

--- a/src/init.js
+++ b/src/init.js
@@ -70,6 +70,7 @@ export function notifyNotification(message) {
 
 const wallets = [
   { walletName: "metamask" },
+  { walletName: "tally" },
   {
     walletName: "trezor",
     appUrl: "https://curve.fi",


### PR DESCRIPTION
Add support for [Tally](https://tally.cash/) wallet. Tally is an open-source browser extension similar to Metamask.
